### PR TITLE
feat(SSH): Add support for SSH endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ Have any feedback or questions? [Create a discussion](https://github.com/TwiN/ga
   - [Monitoring a SCTP endpoint](#monitoring-a-sctp-endpoint)
   - [Monitoring an endpoint using ICMP](#monitoring-an-endpoint-using-icmp)
   - [Monitoring an endpoint using DNS queries](#monitoring-an-endpoint-using-dns-queries)
+  - [Monitoring an endpoint using SSH command](#monitoring-an-endpoint-using-ssh-command)
   - [Monitoring an endpoint using STARTTLS](#monitoring-an-endpoint-using-starttls)
-  - [Monitoring an endpoint using TLS](#monitoring-an-endpoint-using-tls)>
+  - [Monitoring an endpoint using TLS](#monitoring-an-endpoint-using-tls)
   - [Monitoring domain expiration](#monitoring-domain-expiration)
   - [disable-monitoring-lock](#disable-monitoring-lock)
   - [Reloading configuration on the fly](#reloading-configuration-on-the-fly)
@@ -211,6 +212,11 @@ If you want to test it locally, see [Docker](#docker).
 | `endpoints[].dns`                               | Configuration for an endpoint of type DNS. <br />See [Monitoring an endpoint using DNS queries](#monitoring-an-endpoint-using-dns-queries). | `""`                       |
 | `endpoints[].dns.query-type`                    | Query type (e.g. MX)                                                                                                                        | `""`                       |
 | `endpoints[].dns.query-name`                    | Query name (e.g. example.com)                                                                                                               | `""`                       |
+| `endpoints[].ssh`                               | Configuration for an endpoint of type SSH. <br />See [Monitoring an endpoint using SSH command](#monitoring-an-endpoint-using-ssh-command). | `""`                       |
+| `endpoints[].ssh.port`                          | SSH port (e.g. 22)                                                                                                                          | `""`                       |
+| `endpoints[].ssh.user`                          | SSH user (e.g. example)                                                                                                                     | Required `""`              |
+| `endpoints[].ssh.password`                      | SSH password (e.g. password)                                                                                                                | Required `""`              |
+| `endpoints[].ssh.command`                       | SSH command (e.g. uptime)                                                                                                                   | Required `""`              |
 | `endpoints[].alerts[].type`                     | Type of alert. <br />See [Alerting](#alerting) for all valid types.                                                                         | Required `""`              |
 | `endpoints[].alerts[].enabled`                  | Whether to enable the alert.                                                                                                                | `true`                     |
 | `endpoints[].alerts[].failure-threshold`        | Number of failures in a row needed before triggering the alert.                                                                             | `3`                        |
@@ -1522,6 +1528,26 @@ There are two placeholders that can be used in the conditions for endpoints of t
 - The placeholder `[DNS_RCODE]` resolves to the name associated to the response code returned by the query, such as
 `NOERROR`, `FORMERR`, `SERVFAIL`, `NXDOMAIN`, etc.
 
+### Monitoring an endpoint using SSH command
+You can monitor endpoints using SSH by prefixing `endpoints[].url` with `ssh:\\`:
+```yaml
+endpoints:
+  - name: ssh-example
+    url: "ssh://example.com"
+    ssh:
+      port: "22"
+      username: "root"
+      password: "password"
+      command: "uptime"
+    interval: 1m
+    conditions:
+      - "[CONNECTED] == true"
+      - "[EXIT_CODE] == 0"
+```
+
+The following placeholders are supported for endpoints of type SSH:
+- `[CONNECTED]` resolves to `true` if the SSH connection was successful, `false` otherwise
+- `[EXIT_CODE]` resolves to the exit code of the command executed on the remote server (e.g. `0` for success, `1` for failure) to check SSH's availability.
 
 ### Monitoring an endpoint using STARTTLS
 If you have an email server that you want to ensure there are no problems with, monitoring it through STARTTLS
@@ -1537,7 +1563,6 @@ endpoints:
       - "[CONNECTED] == true"
       - "[CERTIFICATE_EXPIRATION] > 48h"
 ```
-
 
 ### Monitoring an endpoint using TLS
 Monitoring endpoints using SSL/TLS encryption, such as LDAP over TLS, can help detect certificate expiration:

--- a/client/client.go
+++ b/client/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/TwiN/whois"
 	"github.com/ishidawataru/sctp"
 	ping "github.com/prometheus-community/pro-bing"
+	"golang.org/x/crypto/ssh"
 )
 
 var (
@@ -152,6 +153,41 @@ func CanPerformTLS(address string, config *Config) (connected bool, certificate 
 		return
 	}
 	return true, verifiedChains[0][0], nil
+}
+
+// CanCreateSSHConnection checks whether a connection can be established and a command can be executed to an address
+// using the SSH protocol.
+func CanCreateSSHConnection(address, port, user, password string, config *Config) (bool, *ssh.Client, error) {
+	cli, err := ssh.Dial("tcp", strings.Join([]string{address, port}, ":"), &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{
+			ssh.Password(password),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	})
+	if err != nil {
+		return false, nil, err
+	}
+
+	return true, cli, nil
+}
+
+// ExecuteSSHCommand executes a command to an address using the SSH protocol.
+func ExecuteSSHCommand(cli *ssh.Client, command string, config *Config) (bool, error) {
+	defer cli.Close()
+
+	sess, err := cli.NewSession()
+	if err != nil {
+		return false, err
+	}
+
+	if err := sess.Run(command); err != nil {
+		return false, err
+	}
+
+	defer sess.Close()
+
+	return true, nil
 }
 
 // Ping checks if an address can be pinged and returns the round-trip time if the address can be pinged

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,15 @@
 endpoints:
+  - name: ssh
+    group: core
+    url: "ssh://127.0.0.1"
+    ssh:
+      user: "root"
+      password: "password"
+      command: "uptime"
+    interval: 1m
+    conditions:
+      - "[CONNECTED] == true"
+      - "[EXIT_CODE] == 0"
   - name: front-end
     group: core
     url: "https://twin.sh/health"

--- a/core/condition.go
+++ b/core/condition.go
@@ -50,6 +50,9 @@ const (
 
 	// DomainExpirationPlaceholder is a placeholder for the duration before the domain expires, in milliseconds.
 	DomainExpirationPlaceholder = "[DOMAIN_EXPIRATION]"
+
+	// ExitCodePlaceholder is a placeholder for the exit code of a command.
+	ExitCodePlaceholder = "[EXIT_CODE]"
 )
 
 // Functions
@@ -150,7 +153,7 @@ func (c Condition) evaluate(result *Result, dontResolveFailedConditions bool) bo
 		return false
 	}
 	if !success {
-		//log.Printf("[Condition][evaluate] Condition '%s' did not succeed because '%s' is false", condition, condition)
+		// log.Printf("[Condition][evaluate] Condition '%s' did not succeed because '%s' is false", condition, condition)
 	}
 	result.ConditionResults = append(result.ConditionResults, &ConditionResult{Condition: conditionToDisplay, Success: success})
 	return success
@@ -253,6 +256,8 @@ func sanitizeAndResolve(elements []string, result *Result) ([]string, []string) 
 			element = strconv.FormatInt(result.CertificateExpiration.Milliseconds(), 10)
 		case DomainExpirationPlaceholder:
 			element = strconv.FormatInt(result.DomainExpiration.Milliseconds(), 10)
+		case ExitCodePlaceholder:
+			element = strconv.Itoa(result.ExitCode)
 		default:
 			// if contains the BodyPlaceholder, then evaluate json path
 			if strings.Contains(element, BodyPlaceholder) {

--- a/core/condition_test.go
+++ b/core/condition_test.go
@@ -371,6 +371,62 @@ func TestCondition_evaluate(t *testing.T) {
 			ExpectedSuccess: false,
 			ExpectedOutput:  "1 == 2",
 		},
+        {
+            Name:            "exit-code-zero",
+            Condition:       Condition("[EXIT_CODE] == 0"),
+            Result:          &Result{ExitCode: 0},
+            ExpectedSuccess: true,
+            ExpectedOutput:  "[EXIT_CODE] == 0",
+        },
+        {
+            Name:            "exit-code-zero-failure",
+            Condition:       Condition("[EXIT_CODE] == 0"),
+            Result:          &Result{ExitCode: 1},
+            ExpectedSuccess: false,
+            ExpectedOutput:  "[EXIT_CODE] (1) == 0",
+        },
+        {
+            Name:            "exit-code-greater-than-zero",
+            Condition:       Condition("[EXIT_CODE] > 0"),
+            Result:          &Result{ExitCode: 1},
+            ExpectedSuccess: true,
+            ExpectedOutput:  "[EXIT_CODE] > 0",
+        },
+        {
+            Name:            "exit-code-greater-than-zero-failure",
+            Condition:       Condition("[EXIT_CODE] > 0"),
+            Result:          &Result{ExitCode: 0},
+            ExpectedSuccess: false,
+            ExpectedOutput:  "[EXIT_CODE] (0) > 0",
+        },
+        {
+            Name:            "exit-code-less-than-zero",
+            Condition:       Condition("[EXIT_CODE] < 0"),
+            Result:          &Result{ExitCode: -1},
+            ExpectedSuccess: true,
+            ExpectedOutput:  "[EXIT_CODE] < 0",
+        },
+        {
+            Name:            "exit-code-less-than-zero-failure",
+            Condition:       Condition("[EXIT_CODE] < 0"),
+            Result:          &Result{ExitCode: 0},
+            ExpectedSuccess: false,
+            ExpectedOutput:  "[EXIT_CODE] (0) < 0",
+        },
+        {
+            Name:            "exit-code-not-zero",
+            Condition:       Condition("[EXIT_CODE] != 0"),
+            Result:          &Result{ExitCode: 1},
+            ExpectedSuccess: true,
+            ExpectedOutput:  "[EXIT_CODE] != 0",
+        },
+        {
+            Name:            "exit-code-not-zero-failure",
+            Condition:       Condition("[EXIT_CODE] != 0"),
+            Result:          &Result{ExitCode: 0},
+            ExpectedSuccess: false,
+            ExpectedOutput:  "[EXIT_CODE] (0) != 0",
+        },
 		///////////////
 		// Functions //
 		///////////////

--- a/core/endpoint.go
+++ b/core/endpoint.go
@@ -17,6 +17,7 @@ import (
 	"github.com/TwiN/gatus/v5/client"
 	"github.com/TwiN/gatus/v5/core/ui"
 	"github.com/TwiN/gatus/v5/util"
+	"golang.org/x/crypto/ssh"
 )
 
 type EndpointType string
@@ -42,6 +43,7 @@ const (
 	EndpointTypeSTARTTLS EndpointType = "STARTTLS"
 	EndpointTypeTLS      EndpointType = "TLS"
 	EndpointTypeHTTP     EndpointType = "HTTP"
+	EndpointTypeSSH      EndpointType = "SSH"
 	EndpointTypeUNKNOWN  EndpointType = "UNKNOWN"
 )
 
@@ -69,6 +71,12 @@ var (
 	// This is because the free whois service we are using should not be abused, especially considering the fact that
 	// the data takes a while to be updated.
 	ErrInvalidEndpointIntervalForDomainExpirationPlaceholder = errors.New("the minimum interval for an endpoint with a condition using the " + DomainExpirationPlaceholder + " placeholder is 300s (5m)")
+	// ErrEndpointWithoutSSHUser is the error with which Gatus will panic if an endpoint with SSH monitoring is configured without a user.
+	ErrEndpointWithoutSSHUser = errors.New("you must specify a user for each endpoint with SSH")
+	// ErrEndpointWithoutSSHPassword is the error with which Gatus will panic if an endpoint with SSH monitoring is configured without a password.
+	ErrEndpointWithoutSSHPassword = errors.New("you must specify a password for each endpoint with SSH")
+	// ErrEndpointWithoutSSHCommand is the error with which Gatus will panic if an endpoint with SSH monitoring is configured without a command.
+	ErrEndpointWithoutSSHCommand = errors.New("you must specify a command for each endpoint with SSH")
 )
 
 // Endpoint is the configuration of a monitored
@@ -120,6 +128,37 @@ type Endpoint struct {
 
 	// NumberOfSuccessesInARow is the number of successful evaluations in a row
 	NumberOfSuccessesInARow int `yaml:"-"`
+
+	// SSH is the configuration of SSH monitoring.
+	SSH *SSH `yaml:"ssh,omitempty"`
+}
+
+type SSH struct {
+	// Port is the port to connect to the SSH server.
+	Port string `yaml:"port,omitempty"`
+	// User is the username to use when connecting to the SSH server.
+	User string `yaml:"user,omitempty"`
+	// Password is the password to use when connecting to the SSH server.
+	Password string `yaml:"password,omitempty"`
+	// Command is the command to execute on the SSH server to determine the health of the endpoint.
+	Command string `yaml:"command,omitempty"`
+}
+
+// Validate validates the endpoint
+func (s *SSH) ValidateAndSetDefaults() error {
+	if s.Port == "" {
+		s.Port = "22"
+	}
+	if s.User == "" {
+		return ErrEndpointWithoutSSHUser
+	}
+	if s.Password == "" {
+		return ErrEndpointWithoutSSHPassword
+	}
+	if s.Command == "" {
+		return ErrEndpointWithoutSSHCommand
+	}
+	return nil
 }
 
 // IsEnabled returns whether the endpoint is enabled or not
@@ -149,6 +188,8 @@ func (endpoint Endpoint) Type() EndpointType {
 		return EndpointTypeTLS
 	case strings.HasPrefix(endpoint.URL, "http://") || strings.HasPrefix(endpoint.URL, "https://"):
 		return EndpointTypeHTTP
+	case strings.HasPrefix(endpoint.URL, "ssh://"):
+		return EndpointTypeSSH
 	default:
 		return EndpointTypeUNKNOWN
 	}
@@ -224,6 +265,9 @@ func (endpoint *Endpoint) ValidateAndSetDefaults() error {
 	_, err := http.NewRequest(endpoint.Method, endpoint.URL, bytes.NewBuffer([]byte(endpoint.Body)))
 	if err != nil {
 		return err
+	}
+	if endpoint.SSH != nil {
+		return endpoint.SSH.ValidateAndSetDefaults()
 	}
 	return nil
 }
@@ -340,6 +384,19 @@ func (endpoint *Endpoint) call(result *Result) {
 		result.Duration = time.Since(startTime)
 	} else if endpointType == EndpointTypeICMP {
 		result.Connected, result.Duration = client.Ping(strings.TrimPrefix(endpoint.URL, "icmp://"), endpoint.ClientConfig)
+	} else if endpointType == EndpointTypeSSH {
+		var cli *ssh.Client
+		result.Connected, cli, err = client.CanCreateSSHConnection(strings.TrimPrefix(endpoint.URL, "ssh://"), endpoint.SSH.Port, endpoint.SSH.User, endpoint.SSH.Password, endpoint.ClientConfig)
+		if err != nil {
+			result.AddError(err.Error())
+			return
+		}
+		result.Success, err = client.ExecuteSSHCommand(cli, endpoint.SSH.Command, endpoint.ClientConfig)
+		if err != nil {
+			result.AddError(err.Error())
+			return
+		}
+		result.Duration = time.Since(startTime)
 	} else {
 		response, err = client.GetHTTPClient(endpoint.ClientConfig).Do(request)
 		result.Duration = time.Since(startTime)

--- a/core/endpoint_test.go
+++ b/core/endpoint_test.go
@@ -256,6 +256,7 @@ func TestEndpoint_Type(t *testing.T) {
 	type args struct {
 		URL string
 		DNS *DNS
+		SSH *SSH
 	}
 	tests := []struct {
 		args args
@@ -312,6 +313,17 @@ func TestEndpoint_Type(t *testing.T) {
 				URL: "https://twin.sh/health",
 			},
 			want: EndpointTypeHTTP,
+		},
+		{
+			args: args{
+				URL: "ssh://example.com:22",
+				SSH: &SSH{
+					User:     "root",
+					Password: "password",
+					Command:  "uptime",
+				},
+			},
+			want: EndpointTypeSSH,
 		},
 		{
 			args: args{
@@ -439,6 +451,78 @@ func TestEndpoint_ValidateAndSetDefaultsWithDNS(t *testing.T) {
 	}
 	if endpoint.DNS.QueryName != "example.com." {
 		t.Error("Endpoint.dns.query-name should be formatted with . suffix")
+	}
+}
+
+func TestEndpoint_ValidateAndSetDefaultsWithSSH(t *testing.T) {
+	tests := []struct {
+		name        string
+		port        string
+		user        string
+		password    string
+		command     string
+		expectedErr error
+	}{
+		{
+			name:        "fail when has no user",
+			port:        "22",
+			user:        "",
+			password:    "password",
+			command:     "uptime",
+			expectedErr: ErrEndpointWithoutSSHUser,
+		},
+		{
+			name:        "fail when has no password",
+			port:        "22",
+			user:        "user",
+			password:    "",
+			command:     "uptime",
+			expectedErr: ErrEndpointWithoutSSHPassword,
+		},
+		{
+			name:        "fail when has no command",
+			port:        "22",
+			user:        "user",
+			password:    "password",
+			command:     "",
+			expectedErr: ErrEndpointWithoutSSHCommand,
+		},
+		{
+			name:        "success when has no port because, 22, default port is set",
+			port:        "",
+			user:        "user",
+			password:    "password",
+			command:     "uptime",
+			expectedErr: nil,
+		},
+		{
+			name:        "success when all fields are set",
+			port:        "22",
+			user:        "user",
+			password:    "password",
+			command:     "uptime",
+			expectedErr: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			endpoint := &Endpoint{
+				Name: "ssh-test",
+				URL:  "https://example.com",
+				SSH: &SSH{
+					Port:     test.port,
+					User:     test.user,
+					Password: test.password,
+					Command:  test.command,
+				},
+				Conditions: []Condition{Condition("[EXIT_CODE] == 0")},
+			}
+			err := endpoint.ValidateAndSetDefaults()
+			if err != test.expectedErr {
+				t.Errorf("expected error %v, got %v", test.expectedErr, err)
+			}
+		})
 	}
 }
 
@@ -665,6 +749,55 @@ func TestIntegrationEvaluateHealthForDNS(t *testing.T) {
 	}
 	if !result.Success {
 		t.Error("Because all conditions passed, this should have been a success")
+	}
+}
+
+func TestIntegrationEvaluateHealthForSSH(t *testing.T) {
+	tests := []struct {
+		name       string
+		endpoint   Endpoint
+		conditions []Condition
+		success    bool
+	}{
+		{
+			name: "ssh-success",
+			endpoint: Endpoint{
+				Name: "ssh-success",
+				URL:  "ssh://localhost",
+				SSH: &SSH{
+					User:     "test",
+					Password: "test",
+					Command:  "uptime",
+				},
+			},
+			conditions: []Condition{Condition("[EXIT_CODE] == 0")},
+			success:    true,
+		},
+		{
+			name: "ssh-failure",
+			endpoint: Endpoint{
+				Name: "ssh-failure",
+				URL:  "ssh://localhost",
+				SSH: &SSH{
+					User:     "test",
+					Password: "test",
+					Command:  "uptime",
+				},
+			},
+			conditions: []Condition{Condition("[EXIT_CODE] == 1")},
+			success:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.endpoint.ValidateAndSetDefaults()
+			test.endpoint.Conditions = test.conditions
+			result := test.endpoint.EvaluateHealth()
+			if result.Success != test.success {
+				t.Errorf("Expected success to be %v, but was %v", test.success, result.Success)
+			}
+		})
 	}
 }
 

--- a/core/result.go
+++ b/core/result.go
@@ -49,6 +49,9 @@ type Result struct {
 	// Note that this field is not persisted in the storage.
 	// It is used for health evaluation as well as debugging purposes.
 	Body []byte `json:"-"`
+
+    // ExitCode is the exit code of the command executed by a ssh:// endpoint to check its health.
+	ExitCode int `json:"exit_code,omitempty"`
 }
 
 // AddError adds an error to the result's list of errors.


### PR DESCRIPTION
This commit adds support for SSH endpoint monitoring. Users can now configure an endpoint to be monitored using an SSH command by prefixing the endpoint's URL with `ssh:\\`. The configuration options for an SSH endpoint include the port, username, password, and command to be executed on the remote server. In addition, two placeholders are supported for SSH endpoints: `[CONNECTED]` and `[EXIT_CODE]`.

This commit also updates the README to include instructions on how to configure SSH endpoints and the placeholders that can be used in their conditions. The README has been updated to include the new SSH-related options in the `endpoints[]` configuration object.

Here's a summary of the changes made in this commit:

- Added support for SSH endpoint monitoring
- Updated the documentation to include instructions on how to configure SSH endpoints and the placeholders that can be used in their conditions