### PR TITLE
chore(SSH): suit SSH feature on existent code

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,10 +213,8 @@ If you want to test it locally, see [Docker](#docker).
 | `endpoints[].dns.query-type`                    | Query type (e.g. MX)                                                                                                                        | `""`                       |
 | `endpoints[].dns.query-name`                    | Query name (e.g. example.com)                                                                                                               | `""`                       |
 | `endpoints[].ssh`                               | Configuration for an endpoint of type SSH. <br />See [Monitoring an endpoint using SSH command](#monitoring-an-endpoint-using-ssh-command). | `""`                       |
-| `endpoints[].ssh.port`                          | SSH port (e.g. 22)                                                                                                                          | `""`                       |
-| `endpoints[].ssh.user`                          | SSH user (e.g. example)                                                                                                                     | Required `""`              |
+| `endpoints[].ssh.username`                      | SSH username (e.g. example)                                                                                                                 | Required `""`              |
 | `endpoints[].ssh.password`                      | SSH password (e.g. password)                                                                                                                | Required `""`              |
-| `endpoints[].ssh.command`                       | SSH command (e.g. uptime)                                                                                                                   | Required `""`              |
 | `endpoints[].alerts[].type`                     | Type of alert. <br />See [Alerting](#alerting) for all valid types.                                                                         | Required `""`              |
 | `endpoints[].alerts[].enabled`                  | Whether to enable the alert.                                                                                                                | `true`                     |
 | `endpoints[].alerts[].failure-threshold`        | Number of failures in a row needed before triggering the alert.                                                                             | `3`                        |
@@ -1533,21 +1531,23 @@ You can monitor endpoints using SSH by prefixing `endpoints[].url` with `ssh:\\`
 ```yaml
 endpoints:
   - name: ssh-example
-    url: "ssh://example.com"
+    url: "ssh://example.com:22" # port is optional. Default is 22.
     ssh:
-      port: "22"
-      username: "root"
+      username: "username"
       password: "password"
-      command: "uptime"
+    body: | 
+      {
+        "command": "uptime"
+      }
     interval: 1m
     conditions:
       - "[CONNECTED] == true"
-      - "[EXIT_CODE] == 0"
+      - "[STATUS] == 0"
 ```
 
 The following placeholders are supported for endpoints of type SSH:
 - `[CONNECTED]` resolves to `true` if the SSH connection was successful, `false` otherwise
-- `[EXIT_CODE]` resolves to the exit code of the command executed on the remote server (e.g. `0` for success, `1` for failure) to check SSH's availability.
+- `[STATUS]` resolves the exit code of the command executed on the remote server (e.g. `0` for success)
 
 ### Monitoring an endpoint using STARTTLS
 If you have an email server that you want to ensure there are no problems with, monitoring it through STARTTLS

--- a/client/client.go
+++ b/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -157,13 +158,26 @@ func CanPerformTLS(address string, config *Config) (connected bool, certificate 
 
 // CanCreateSSHConnection checks whether a connection can be established and a command can be executed to an address
 // using the SSH protocol.
-func CanCreateSSHConnection(address, port, user, password string, config *Config) (bool, *ssh.Client, error) {
+func CanCreateSSHConnection(address, username, password string, config *Config) (bool, *ssh.Client, error) {
+	var port string
+	if strings.Contains(address, ":") {
+		addressAndPort := strings.Split(address, ":")
+		if len(addressAndPort) != 2 {
+			return false, nil, errors.New("invalid address for ssh, format must be host:port")
+		}
+		address = addressAndPort[0]
+		port = addressAndPort[1]
+	} else {
+		port = "22"
+	}
+
 	cli, err := ssh.Dial("tcp", strings.Join([]string{address, port}, ":"), &ssh.ClientConfig{
-		User: user,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		User:            username,
 		Auth: []ssh.AuthMethod{
 			ssh.Password(password),
 		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout: config.Timeout,
 	})
 	if err != nil {
 		return false, nil, err
@@ -173,21 +187,41 @@ func CanCreateSSHConnection(address, port, user, password string, config *Config
 }
 
 // ExecuteSSHCommand executes a command to an address using the SSH protocol.
-func ExecuteSSHCommand(cli *ssh.Client, command string, config *Config) (bool, error) {
+func ExecuteSSHCommand(cli *ssh.Client, body string, config *Config) (bool, int, error) {
+	type Body struct {
+		Command string `json:"command"`
+	}
+
 	defer cli.Close()
+
+	var b Body
+	if err := json.Unmarshal([]byte(body), &b); err != nil {
+		return false, 0, err
+	}
 
 	sess, err := cli.NewSession()
 	if err != nil {
-		return false, err
+		return false, 0, err
 	}
 
-	if err := sess.Run(command); err != nil {
-		return false, err
+	err = sess.Start(b.Command)
+	if err != nil {
+		return false, 0, err
 	}
 
 	defer sess.Close()
 
-	return true, nil
+	err = sess.Wait()
+	if err == nil {
+		return true, 0, nil
+	}
+
+	e, ok := err.(*ssh.ExitError)
+	if !ok {
+		return false, 0, err
+	}
+
+	return true, e.ExitStatus(), nil
 }
 
 // Ping checks if an address can be pinged and returns the round-trip time if the address can be pinged

--- a/config.yaml
+++ b/config.yaml
@@ -1,15 +1,17 @@
 endpoints:
   - name: ssh
     group: core
-    url: "ssh://127.0.0.1"
+    url: "ssh://example.org"
     ssh:
-      user: "root"
-      password: "password"
-      command: "uptime"
-    interval: 1m
+      username: "example"
+      password: "example"
+    body: | 
+      {
+        "command": "uptime"
+      }
+    interval: 1s
     conditions:
-      - "[CONNECTED] == true"
-      - "[EXIT_CODE] == 0"
+      - "[STATUS] == 0"
   - name: front-end
     group: core
     url: "https://twin.sh/health"

--- a/core/condition_test.go
+++ b/core/condition_test.go
@@ -371,62 +371,6 @@ func TestCondition_evaluate(t *testing.T) {
 			ExpectedSuccess: false,
 			ExpectedOutput:  "1 == 2",
 		},
-        {
-            Name:            "exit-code-zero",
-            Condition:       Condition("[EXIT_CODE] == 0"),
-            Result:          &Result{ExitCode: 0},
-            ExpectedSuccess: true,
-            ExpectedOutput:  "[EXIT_CODE] == 0",
-        },
-        {
-            Name:            "exit-code-zero-failure",
-            Condition:       Condition("[EXIT_CODE] == 0"),
-            Result:          &Result{ExitCode: 1},
-            ExpectedSuccess: false,
-            ExpectedOutput:  "[EXIT_CODE] (1) == 0",
-        },
-        {
-            Name:            "exit-code-greater-than-zero",
-            Condition:       Condition("[EXIT_CODE] > 0"),
-            Result:          &Result{ExitCode: 1},
-            ExpectedSuccess: true,
-            ExpectedOutput:  "[EXIT_CODE] > 0",
-        },
-        {
-            Name:            "exit-code-greater-than-zero-failure",
-            Condition:       Condition("[EXIT_CODE] > 0"),
-            Result:          &Result{ExitCode: 0},
-            ExpectedSuccess: false,
-            ExpectedOutput:  "[EXIT_CODE] (0) > 0",
-        },
-        {
-            Name:            "exit-code-less-than-zero",
-            Condition:       Condition("[EXIT_CODE] < 0"),
-            Result:          &Result{ExitCode: -1},
-            ExpectedSuccess: true,
-            ExpectedOutput:  "[EXIT_CODE] < 0",
-        },
-        {
-            Name:            "exit-code-less-than-zero-failure",
-            Condition:       Condition("[EXIT_CODE] < 0"),
-            Result:          &Result{ExitCode: 0},
-            ExpectedSuccess: false,
-            ExpectedOutput:  "[EXIT_CODE] (0) < 0",
-        },
-        {
-            Name:            "exit-code-not-zero",
-            Condition:       Condition("[EXIT_CODE] != 0"),
-            Result:          &Result{ExitCode: 1},
-            ExpectedSuccess: true,
-            ExpectedOutput:  "[EXIT_CODE] != 0",
-        },
-        {
-            Name:            "exit-code-not-zero-failure",
-            Condition:       Condition("[EXIT_CODE] != 0"),
-            Result:          &Result{ExitCode: 0},
-            ExpectedSuccess: false,
-            ExpectedOutput:  "[EXIT_CODE] (0) != 0",
-        },
 		///////////////
 		// Functions //
 		///////////////

--- a/core/endpoint.go
+++ b/core/endpoint.go
@@ -71,12 +71,10 @@ var (
 	// This is because the free whois service we are using should not be abused, especially considering the fact that
 	// the data takes a while to be updated.
 	ErrInvalidEndpointIntervalForDomainExpirationPlaceholder = errors.New("the minimum interval for an endpoint with a condition using the " + DomainExpirationPlaceholder + " placeholder is 300s (5m)")
-	// ErrEndpointWithoutSSHUser is the error with which Gatus will panic if an endpoint with SSH monitoring is configured without a user.
-	ErrEndpointWithoutSSHUser = errors.New("you must specify a user for each endpoint with SSH")
+	// ErrEndpointWithoutSSHUsername is the error with which Gatus will panic if an endpoint with SSH monitoring is configured without a user.
+	ErrEndpointWithoutSSHUsername = errors.New("you must specify a username for each endpoint with SSH")
 	// ErrEndpointWithoutSSHPassword is the error with which Gatus will panic if an endpoint with SSH monitoring is configured without a password.
 	ErrEndpointWithoutSSHPassword = errors.New("you must specify a password for each endpoint with SSH")
-	// ErrEndpointWithoutSSHCommand is the error with which Gatus will panic if an endpoint with SSH monitoring is configured without a command.
-	ErrEndpointWithoutSSHCommand = errors.New("you must specify a command for each endpoint with SSH")
 )
 
 // Endpoint is the configuration of a monitored
@@ -134,29 +132,19 @@ type Endpoint struct {
 }
 
 type SSH struct {
-	// Port is the port to connect to the SSH server.
-	Port string `yaml:"port,omitempty"`
-	// User is the username to use when connecting to the SSH server.
-	User string `yaml:"user,omitempty"`
+	// Username is the username to use when connecting to the SSH server.
+	Username string `yaml:"username,omitempty"`
 	// Password is the password to use when connecting to the SSH server.
 	Password string `yaml:"password,omitempty"`
-	// Command is the command to execute on the SSH server to determine the health of the endpoint.
-	Command string `yaml:"command,omitempty"`
 }
 
 // Validate validates the endpoint
 func (s *SSH) ValidateAndSetDefaults() error {
-	if s.Port == "" {
-		s.Port = "22"
-	}
-	if s.User == "" {
-		return ErrEndpointWithoutSSHUser
+	if s.Username == "" {
+		return ErrEndpointWithoutSSHUsername
 	}
 	if s.Password == "" {
 		return ErrEndpointWithoutSSHPassword
-	}
-	if s.Command == "" {
-		return ErrEndpointWithoutSSHCommand
 	}
 	return nil
 }
@@ -386,12 +374,12 @@ func (endpoint *Endpoint) call(result *Result) {
 		result.Connected, result.Duration = client.Ping(strings.TrimPrefix(endpoint.URL, "icmp://"), endpoint.ClientConfig)
 	} else if endpointType == EndpointTypeSSH {
 		var cli *ssh.Client
-		result.Connected, cli, err = client.CanCreateSSHConnection(strings.TrimPrefix(endpoint.URL, "ssh://"), endpoint.SSH.Port, endpoint.SSH.User, endpoint.SSH.Password, endpoint.ClientConfig)
+		result.Connected, cli, err = client.CanCreateSSHConnection(strings.TrimPrefix(endpoint.URL, "ssh://"), endpoint.SSH.Username, endpoint.SSH.Password, endpoint.ClientConfig)
 		if err != nil {
 			result.AddError(err.Error())
 			return
 		}
-		result.Success, err = client.ExecuteSSHCommand(cli, endpoint.SSH.Command, endpoint.ClientConfig)
+		result.Success, result.HTTPStatus, err = client.ExecuteSSHCommand(cli, endpoint.Body, endpoint.ClientConfig)
 		if err != nil {
 			result.AddError(err.Error())
 			return

--- a/core/endpoint_test.go
+++ b/core/endpoint_test.go
@@ -318,9 +318,8 @@ func TestEndpoint_Type(t *testing.T) {
 			args: args{
 				URL: "ssh://example.com:22",
 				SSH: &SSH{
-					User:     "root",
+					Username: "root",
 					Password: "password",
-					Command:  "uptime",
 				},
 			},
 			want: EndpointTypeSSH,
@@ -457,50 +456,26 @@ func TestEndpoint_ValidateAndSetDefaultsWithDNS(t *testing.T) {
 func TestEndpoint_ValidateAndSetDefaultsWithSSH(t *testing.T) {
 	tests := []struct {
 		name        string
-		port        string
-		user        string
+		username    string
 		password    string
-		command     string
 		expectedErr error
 	}{
 		{
 			name:        "fail when has no user",
-			port:        "22",
-			user:        "",
+			username:    "",
 			password:    "password",
-			command:     "uptime",
-			expectedErr: ErrEndpointWithoutSSHUser,
+			expectedErr: ErrEndpointWithoutSSHUsername,
 		},
 		{
 			name:        "fail when has no password",
-			port:        "22",
-			user:        "user",
+			username:    "username",
 			password:    "",
-			command:     "uptime",
 			expectedErr: ErrEndpointWithoutSSHPassword,
 		},
 		{
-			name:        "fail when has no command",
-			port:        "22",
-			user:        "user",
-			password:    "password",
-			command:     "",
-			expectedErr: ErrEndpointWithoutSSHCommand,
-		},
-		{
-			name:        "success when has no port because, 22, default port is set",
-			port:        "",
-			user:        "user",
-			password:    "password",
-			command:     "uptime",
-			expectedErr: nil,
-		},
-		{
 			name:        "success when all fields are set",
-			port:        "22",
-			user:        "user",
+			username:    "username",
 			password:    "password",
-			command:     "uptime",
 			expectedErr: nil,
 		},
 	}
@@ -511,12 +486,10 @@ func TestEndpoint_ValidateAndSetDefaultsWithSSH(t *testing.T) {
 				Name: "ssh-test",
 				URL:  "https://example.com",
 				SSH: &SSH{
-					Port:     test.port,
-					User:     test.user,
+					Username: test.username,
 					Password: test.password,
-					Command:  test.command,
 				},
-				Conditions: []Condition{Condition("[EXIT_CODE] == 0")},
+				Conditions: []Condition{Condition("[STATUS] == 0")},
 			}
 			err := endpoint.ValidateAndSetDefaults()
 			if err != test.expectedErr {
@@ -765,12 +738,12 @@ func TestIntegrationEvaluateHealthForSSH(t *testing.T) {
 				Name: "ssh-success",
 				URL:  "ssh://localhost",
 				SSH: &SSH{
-					User:     "test",
+					Username: "test",
 					Password: "test",
-					Command:  "uptime",
 				},
+				Body: "{ \"command\": \"uptime\" }",
 			},
-			conditions: []Condition{Condition("[EXIT_CODE] == 0")},
+			conditions: []Condition{Condition("[STATUS] == 0")},
 			success:    true,
 		},
 		{
@@ -779,12 +752,12 @@ func TestIntegrationEvaluateHealthForSSH(t *testing.T) {
 				Name: "ssh-failure",
 				URL:  "ssh://localhost",
 				SSH: &SSH{
-					User:     "test",
+					Username: "test",
 					Password: "test",
-					Command:  "uptime",
 				},
+				Body: "{ \"command\": \"uptime\" }",
 			},
-			conditions: []Condition{Condition("[EXIT_CODE] == 1")},
+			conditions: []Condition{Condition("[STATUS] == 1")},
 			success:    false,
 		},
 	}


### PR DESCRIPTION
remove `EXIT_CODE` placeholder in favor of `STATUS`, what already exists, `port` attribute from SSH structure, setting it to URL as optional, and `command`, passing it on to the body.